### PR TITLE
모든일지 관련 예외클래스 분리 및 상담일지 api url, 메소드명 수정

### DIFF
--- a/src/main/java/com/example/tnote/base/exception/ErrorCodes.java
+++ b/src/main/java/com/example/tnote/base/exception/ErrorCodes.java
@@ -39,7 +39,6 @@ public enum ErrorCodes {
     SUBJECT_NOT_FOUND(HttpStatus.NOT_FOUND, "subject is not found"),
     SCHEDULE_NOT_FOUND(HttpStatus.NOT_FOUND, "subject is not found"),
     TODAY_IS_WRONG_WITH_DATE(HttpStatus.NOT_FOUND, "different date with today"),
-    DATES_NOT_INCLUDED_IN_SEMESTER(HttpStatus.NOT_FOUND, "incorrect date in subject"),
     WRONG_CLASS_TIME(HttpStatus.NOT_FOUND, "last class is invalid"),
 
     // todo

--- a/src/main/java/com/example/tnote/base/exception/ErrorCodes.java
+++ b/src/main/java/com/example/tnote/base/exception/ErrorCodes.java
@@ -9,11 +9,6 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCodes {
     //todo 삭제 할 enum 클래스입니다.
 
-    // observation
-    OBSERVATION_NOT_FOUNT(HttpStatus.NOT_FOUND, "not found observation"),
-    INVALID_OBSERVATION_DATA(HttpStatus.BAD_REQUEST, "Invalid observation data"),
-    INVALID_OBSERVATION_DATE(HttpStatus.BAD_REQUEST, "Observation date must be within the schedule dates"),
-
     // common
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "bad request"),
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "unauthorized"),

--- a/src/main/java/com/example/tnote/base/exception/ErrorCodes.java
+++ b/src/main/java/com/example/tnote/base/exception/ErrorCodes.java
@@ -9,18 +9,10 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCodes {
     //todo 삭제 할 enum 클래스입니다.
 
-
-    // consultation
-
     // observation
     OBSERVATION_NOT_FOUNT(HttpStatus.NOT_FOUND, "not found observation"),
     INVALID_OBSERVATION_DATA(HttpStatus.BAD_REQUEST, "Invalid observation data"),
     INVALID_OBSERVATION_DATE(HttpStatus.BAD_REQUEST, "Observation date must be within the schedule dates"),
-
-    // proceeding
-    PROCEEDING_NOT_FOUNT(HttpStatus.NOT_FOUND, "not found proceeding"),
-    INVALID_PROCEEDING_DATE(HttpStatus.BAD_REQUEST, "Proceeding date must be within the schedule dates"),
-    INVALID_PROCEEDING_DATA(HttpStatus.BAD_REQUEST, "Invalid proceeding data"),
 
     // common
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "bad request"),

--- a/src/main/java/com/example/tnote/base/exception/ErrorCodes.java
+++ b/src/main/java/com/example/tnote/base/exception/ErrorCodes.java
@@ -9,17 +9,8 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCodes {
     //todo 삭제 할 enum 클래스입니다.
 
-    // class log
-    CLASS_LOG_NOT_FOUNT(HttpStatus.NOT_FOUND, "not found classLog"),
-    INVALID_CLASS_LOG_DATA(HttpStatus.BAD_REQUEST, "Invalid class log data"),
-    INVALID_CLASS_LOG_DATE(HttpStatus.BAD_REQUEST, "ClassLog date must be within the schedule dates"),
 
     // consultation
-    CONSULTATION_NOT_FOUNT(HttpStatus.NOT_FOUND, "not found consultation"),
-    INVALID_CONSULTATION_DATA(HttpStatus.BAD_REQUEST, "Invalid consultation log data"),
-    INVALID_COUNSELING_TYPE(HttpStatus.BAD_REQUEST, "Invalid counseling type"),
-    INVALID_COUNSELING_FIELD(HttpStatus.BAD_REQUEST, "Invalid counseling field"),
-    INVALID_CONSULTATION_DATE(HttpStatus.BAD_REQUEST, "Consultation date must be within the schedule dates"),
 
     // observation
     OBSERVATION_NOT_FOUNT(HttpStatus.NOT_FOUND, "not found observation"),

--- a/src/main/java/com/example/tnote/boundedContext/archive/service/ArchiveService.java
+++ b/src/main/java/com/example/tnote/boundedContext/archive/service/ArchiveService.java
@@ -33,6 +33,8 @@ import com.example.tnote.boundedContext.proceeding.entity.Proceeding;
 import com.example.tnote.boundedContext.proceeding.repository.query.ProceedingQueryRepository;
 import com.example.tnote.boundedContext.proceeding.service.ProceedingService;
 import com.example.tnote.boundedContext.schedule.entity.Schedule;
+import com.example.tnote.boundedContext.schedule.exception.ScheduleErrorCode;
+import com.example.tnote.boundedContext.schedule.exception.ScheduleException;
 import com.example.tnote.boundedContext.schedule.repository.ScheduleRepository;
 import com.example.tnote.boundedContext.todo.dto.TodoResponseDto;
 import com.example.tnote.boundedContext.todo.service.TodoService;
@@ -186,8 +188,8 @@ public class ArchiveService {
         LocalDate endDate = LocalDate.now();
 
         if ("title".equals(searchType)) {
-            logs.addAll(classLogService.findByTitleContainingAndDateBetween(keyword, startDate, endDate, userId));
-            logs.addAll(consultationService.findByTitleContainingAndDateBetween(keyword, startDate, endDate, userId));
+            logs.addAll(classLogService.findByTitleContaining(keyword, startDate, endDate, userId));
+            logs.addAll(consultationService.findByTitleContaining(keyword, startDate, endDate, userId));
             logs.addAll(proceedingService.findByTitleContainingAndDateBetween(keyword, startDate, endDate, userId));
             logs.addAll(observationService.findByTitleContainingAndDateBetween(keyword, startDate, endDate, userId));
         }
@@ -200,7 +202,7 @@ public class ArchiveService {
         if ("titleAndContent".equals(searchType)) {
             logs.addAll(classLogService.findByTitleOrClassContents(keyword, startDate,
                     endDate, userId));
-            logs.addAll(consultationService.findByTitleOrPlanOrClassContentsContainingAndDateBetween(keyword, startDate,
+            logs.addAll(consultationService.findByTitleOrPlanOrClassContents(keyword, startDate,
                     endDate, userId));
             logs.addAll(proceedingService.findByTitleOrPlanOrClassContentsContainingAndDateBetween(keyword, startDate,
                     endDate, userId));
@@ -227,12 +229,12 @@ public class ArchiveService {
 
     public ArchiveResponseDto readDailyLogs(Long userId, Long scheduleId, LocalDate date) {
         Schedule schedule = scheduleRepository.findById(scheduleId)
-                .orElseThrow(() -> CustomExceptions.SCHEDULE_NOT_FOUND);
+                .orElseThrow(() -> new ScheduleException(ScheduleErrorCode.SCHEDULE_NOT_FOUND));
         LocalDate startDate = schedule.getStartDate();
         LocalDate endDate = schedule.getEndDate();
 
         if (date.isBefore(startDate) || (endDate != null && date.isAfter(endDate))) {
-            throw new CustomExceptions(ErrorCodes.DATES_NOT_INCLUDED_IN_SEMESTER);
+            throw new ScheduleException(ScheduleErrorCode.DATES_NOT_INCLUDED_IN_SEMESTER);
         }
         List<ClassLogResponseDto> classLogs = classLogService.readDailyClassLog(userId, scheduleId, date);
         List<ConsultationResponseDto> consultations = consultationService.readDailyConsultations(userId, scheduleId,

--- a/src/main/java/com/example/tnote/boundedContext/archive/service/ArchiveService.java
+++ b/src/main/java/com/example/tnote/boundedContext/archive/service/ArchiveService.java
@@ -188,14 +188,14 @@ public class ArchiveService {
         LocalDate endDate = LocalDate.now();
 
         if ("title".equals(searchType)) {
-            logs.addAll(classLogService.findByTitleContaining(keyword, startDate, endDate, userId));
-            logs.addAll(consultationService.findByTitleContaining(keyword, startDate, endDate, userId));
+            logs.addAll(classLogService.findByTitle(keyword, startDate, endDate, userId));
+            logs.addAll(consultationService.findByTitle(keyword, startDate, endDate, userId));
             logs.addAll(proceedingService.findByTitleContainingAndDateBetween(keyword, startDate, endDate, userId));
             logs.addAll(observationService.findByTitleContainingAndDateBetween(keyword, startDate, endDate, userId));
         }
         if ("content".equals((searchType))) {
             logs.addAll(classLogService.findByClassContents(keyword, startDate, endDate, userId));
-            logs.addAll(consultationService.findByContentsContaining(keyword, startDate, endDate, userId));
+            logs.addAll(consultationService.findByContents(keyword, startDate, endDate, userId));
             logs.addAll(proceedingService.findByContentsContaining(keyword, startDate, endDate, userId));
             logs.addAll(observationService.findByContentsContaining(keyword, startDate, endDate, userId));
         }

--- a/src/main/java/com/example/tnote/boundedContext/classLog/service/ClassLogService.java
+++ b/src/main/java/com/example/tnote/boundedContext/classLog/service/ClassLogService.java
@@ -100,7 +100,7 @@ public class ClassLogService {
     }
 
     @Transactional(readOnly = true)
-    public List<ClassLogResponseDto> findByTitleContaining(String keyword, LocalDate startDate,
+    public List<ClassLogResponseDto> findByTitle(String keyword, LocalDate startDate,
                                                                          LocalDate endDate, Long userId) {
         LocalDateTime startOfDay = DateUtils.getStartOfDay(startDate);
         LocalDateTime endOfDay = DateUtils.getEndOfDay(endDate);

--- a/src/main/java/com/example/tnote/boundedContext/classLog/service/ClassLogService.java
+++ b/src/main/java/com/example/tnote/boundedContext/classLog/service/ClassLogService.java
@@ -16,8 +16,12 @@ import com.example.tnote.boundedContext.classLog.repository.ClassLogImageReposit
 import com.example.tnote.boundedContext.classLog.repository.ClassLogRepository;
 import com.example.tnote.boundedContext.recentLog.service.RecentLogService;
 import com.example.tnote.boundedContext.schedule.entity.Schedule;
+import com.example.tnote.boundedContext.schedule.exception.ScheduleErrorCode;
+import com.example.tnote.boundedContext.schedule.exception.ScheduleException;
 import com.example.tnote.boundedContext.schedule.repository.ScheduleRepository;
 import com.example.tnote.boundedContext.user.entity.User;
+import com.example.tnote.boundedContext.user.exception.UserErrorCode;
+import com.example.tnote.boundedContext.user.exception.UserException;
 import com.example.tnote.boundedContext.user.repository.UserRepository;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -261,12 +265,12 @@ public class ClassLogService {
 
     private User findUserById(Long userId) {
         return userRepository.findById(userId)
-                .orElseThrow(() -> CustomExceptions.USER_NOT_FOUND);
+                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
     }
 
     private Schedule findScheduleById(Long scheduleId) {
         return scheduleRepository.findById(scheduleId)
-                .orElseThrow(() -> CustomExceptions.SCHEDULE_NOT_FOUND);
+                .orElseThrow(() -> new ScheduleException(ScheduleErrorCode.SCHEDULE_NOT_FOUND));
     }
 
     private ClassLog findByIdAndUserId(Long classLogId, Long userId) {

--- a/src/main/java/com/example/tnote/boundedContext/classLog/service/ClassLogService.java
+++ b/src/main/java/com/example/tnote/boundedContext/classLog/service/ClassLogService.java
@@ -100,7 +100,7 @@ public class ClassLogService {
     }
 
     @Transactional(readOnly = true)
-    public List<ClassLogResponseDto> findByTitleContainingAndDateBetween(String keyword, LocalDate startDate,
+    public List<ClassLogResponseDto> findByTitleContaining(String keyword, LocalDate startDate,
                                                                          LocalDate endDate, Long userId) {
         LocalDateTime startOfDay = DateUtils.getStartOfDay(startDate);
         LocalDateTime endOfDay = DateUtils.getEndOfDay(endDate);

--- a/src/main/java/com/example/tnote/boundedContext/consultation/controller/ConsultationController.java
+++ b/src/main/java/com/example/tnote/boundedContext/consultation/controller/ConsultationController.java
@@ -37,14 +37,14 @@ import org.springframework.web.multipart.MultipartFile;
 public class ConsultationController {
     private final ConsultationService consultationService;
 
-    @GetMapping("/fields")
-    public ResponseEntity<Result> getCounselingFields() {
+    @GetMapping("/field")
+    public ResponseEntity<Result> getCounselingField() {
         List<CounselingField> response = Arrays.asList(CounselingField.values());
         return ResponseEntity.ok(Result.of(response));
     }
 
-    @GetMapping("/types")
-    public ResponseEntity<Result> getCounselingTypes() {
+    @GetMapping("/type")
+    public ResponseEntity<Result> getCounselingType() {
         List<CounselingType> response = Arrays.asList(CounselingType.values());
         return ResponseEntity.ok(Result.of(response));
     }

--- a/src/main/java/com/example/tnote/boundedContext/consultation/controller/ConsultationController.java
+++ b/src/main/java/com/example/tnote/boundedContext/consultation/controller/ConsultationController.java
@@ -60,7 +60,7 @@ public class ConsultationController {
         return ResponseEntity.ok(Result.of(consultationResponseDto));
     }
 
-    @GetMapping("/{scheduleId}/consultation")
+    @GetMapping("/{scheduleId}")
     public ResponseEntity<Result> getAllConsultation(@AuthenticationPrincipal PrincipalDetails principalDetails,
                                                       @PathVariable Long scheduleId,
                                                       @RequestParam(value = "page", required = false, defaultValue = "0") int page,

--- a/src/main/java/com/example/tnote/boundedContext/consultation/controller/ConsultationController.java
+++ b/src/main/java/com/example/tnote/boundedContext/consultation/controller/ConsultationController.java
@@ -60,8 +60,8 @@ public class ConsultationController {
         return ResponseEntity.ok(Result.of(consultationResponseDto));
     }
 
-    @GetMapping("/{scheduleId}/consultations")
-    public ResponseEntity<Result> getAllConsultations(@AuthenticationPrincipal PrincipalDetails principalDetails,
+    @GetMapping("/{scheduleId}/consultation")
+    public ResponseEntity<Result> getAllConsultation(@AuthenticationPrincipal PrincipalDetails principalDetails,
                                                       @PathVariable Long scheduleId,
                                                       @RequestParam(value = "page", required = false, defaultValue = "0") int page,
                                                       @RequestParam(value = "size", required = false, defaultValue = "4") int size) {

--- a/src/main/java/com/example/tnote/boundedContext/consultation/controller/ConsultationController.java
+++ b/src/main/java/com/example/tnote/boundedContext/consultation/controller/ConsultationController.java
@@ -32,7 +32,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 @Slf4j
 @RestController
-@RequestMapping("/tnote/consultation")
+@RequestMapping("/tnote/v1/consultation")
 @RequiredArgsConstructor
 public class ConsultationController {
     private final ConsultationService consultationService;

--- a/src/main/java/com/example/tnote/boundedContext/consultation/dto/ConsultationRequestDto.java
+++ b/src/main/java/com/example/tnote/boundedContext/consultation/dto/ConsultationRequestDto.java
@@ -5,6 +5,8 @@ import com.example.tnote.base.utils.DateUtils;
 import com.example.tnote.boundedContext.consultation.entity.Consultation;
 import com.example.tnote.boundedContext.consultation.entity.CounselingField;
 import com.example.tnote.boundedContext.consultation.entity.CounselingType;
+import com.example.tnote.boundedContext.consultation.exception.ConsultationErrorCode;
+import com.example.tnote.boundedContext.consultation.exception.ConsultationException;
 import com.example.tnote.boundedContext.schedule.entity.Schedule;
 import com.example.tnote.boundedContext.user.entity.User;
 import java.time.LocalDateTime;
@@ -33,13 +35,13 @@ public class ConsultationRequestDto {
 
     private void validateCounselingField() {
         if (counselingField == null || EnumUtils.isValidEnum(CounselingField.class, counselingField.name())) {
-            throw CustomExceptions.INVALID_COUNSELING_FIELD;
+            throw new ConsultationException(ConsultationErrorCode.INVALID_COUNSELING_FIELD);
         }
     }
 
     private void validateCounselingType() {
         if (counselingType == null || EnumUtils.isValidEnum(CounselingType.class, counselingType.name())) {
-            throw CustomExceptions.INVALID_COUNSELING_TYPE;
+            throw new ConsultationException(ConsultationErrorCode.INVALID_COUNSELING_TYPE);
         }
     }
 

--- a/src/main/java/com/example/tnote/boundedContext/consultation/dto/ConsultationUpdateRequestDto.java
+++ b/src/main/java/com/example/tnote/boundedContext/consultation/dto/ConsultationUpdateRequestDto.java
@@ -3,6 +3,8 @@ package com.example.tnote.boundedContext.consultation.dto;
 import com.example.tnote.base.exception.CustomExceptions;
 import com.example.tnote.boundedContext.consultation.entity.CounselingField;
 import com.example.tnote.boundedContext.consultation.entity.CounselingType;
+import com.example.tnote.boundedContext.consultation.exception.ConsultationErrorCode;
+import com.example.tnote.boundedContext.consultation.exception.ConsultationException;
 import java.time.LocalDateTime;
 import java.util.EnumSet;
 import lombok.Getter;
@@ -46,11 +48,11 @@ public class ConsultationUpdateRequestDto {
     }
     public void validateEnums() {
         if (hasCounselingField() && !EnumSet.allOf(CounselingField.class).contains(counselingField)) {
-            throw CustomExceptions.INVALID_COUNSELING_FIELD;
+            throw new ConsultationException(ConsultationErrorCode.INVALID_COUNSELING_FIELD);
         }
 
         if (hasCounselingType() && !EnumSet.allOf(CounselingType.class).contains(counselingType)) {
-            throw CustomExceptions.INVALID_COUNSELING_TYPE;
+            throw new ConsultationException(ConsultationErrorCode.INVALID_COUNSELING_TYPE);
         }
     }
 }

--- a/src/main/java/com/example/tnote/boundedContext/consultation/exception/ConsultationErrorCode.java
+++ b/src/main/java/com/example/tnote/boundedContext/consultation/exception/ConsultationErrorCode.java
@@ -1,0 +1,27 @@
+package com.example.tnote.boundedContext.consultation.exception;
+
+import com.example.tnote.base.exception.ErrorCode;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum ConsultationErrorCode implements ErrorCode {
+    CONSULTATION_NOT_FOUNT(HttpStatus.NOT_FOUND, "not found consultation"),
+    INVALID_CONSULTATION_DATA(HttpStatus.BAD_REQUEST, "Invalid consultation log data"),
+    INVALID_COUNSELING_TYPE(HttpStatus.BAD_REQUEST, "Invalid counseling type"),
+    INVALID_COUNSELING_FIELD(HttpStatus.BAD_REQUEST, "Invalid counseling field"),
+    INVALID_CONSULTATION_DATE(HttpStatus.BAD_REQUEST, "Consultation date must be within the schedule dates");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    ConsultationErrorCode(final HttpStatus httpStatus, final String message) {
+        this.httpStatus = httpStatus;
+        this.message = message;
+    }
+
+    @Override
+    public String getCode() {
+        return "";
+    }
+}

--- a/src/main/java/com/example/tnote/boundedContext/consultation/exception/ConsultationException.java
+++ b/src/main/java/com/example/tnote/boundedContext/consultation/exception/ConsultationException.java
@@ -1,0 +1,10 @@
+package com.example.tnote.boundedContext.consultation.exception;
+
+import com.example.tnote.base.exception.CustomException;
+import com.example.tnote.base.exception.ErrorCode;
+
+public class ConsultationException extends CustomException {
+    public ConsultationException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/example/tnote/boundedContext/consultation/service/ConsultationService.java
+++ b/src/main/java/com/example/tnote/boundedContext/consultation/service/ConsultationService.java
@@ -1,7 +1,5 @@
 package com.example.tnote.boundedContext.consultation.service;
 
-import com.example.tnote.base.exception.CustomExceptions;
-import com.example.tnote.base.exception.ErrorCodes;
 import com.example.tnote.base.utils.AwsS3Uploader;
 import com.example.tnote.base.utils.DateUtils;
 import com.example.tnote.boundedContext.consultation.dto.ConsultationDeleteResponseDto;
@@ -30,7 +28,6 @@ import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.http.impl.conn.ConnectionShutdownException;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
@@ -132,8 +129,8 @@ public class ConsultationService {
     }
 
     @Transactional(readOnly = true)
-    public List<ConsultationResponseDto> findByTitleContainingAndDateBetween(String keyword, LocalDate startDate,
-                                                                             LocalDate endDate, Long userId) {
+    public List<ConsultationResponseDto> findByTitleContaining(String keyword, LocalDate startDate,
+                                                               LocalDate endDate, Long userId) {
         LocalDateTime startOfDay = DateUtils.getStartOfDay(startDate);
         LocalDateTime endOfDay = DateUtils.getEndOfDay(endDate);
         List<Consultation> logs = consultationRepository.findByTitleContaining(keyword, startOfDay, endOfDay,
@@ -156,10 +153,10 @@ public class ConsultationService {
     }
 
     @Transactional(readOnly = true)
-    public List<ConsultationResponseDto> findByTitleOrPlanOrClassContentsContainingAndDateBetween(String keyword,
-                                                                                                  LocalDate startDate,
-                                                                                                  LocalDate endDate,
-                                                                                                  Long userId) {
+    public List<ConsultationResponseDto> findByTitleOrPlanOrClassContents(String keyword,
+                                                                          LocalDate startDate,
+                                                                          LocalDate endDate,
+                                                                          Long userId) {
         LocalDateTime startOfDay = DateUtils.getStartOfDay(startDate);
         LocalDateTime endOfDay = DateUtils.getEndOfDay(endDate);
         List<Consultation> logs = consultationRepository.findByTitleOrPlanOrClassContentsContaining(keyword,

--- a/src/main/java/com/example/tnote/boundedContext/consultation/service/ConsultationService.java
+++ b/src/main/java/com/example/tnote/boundedContext/consultation/service/ConsultationService.java
@@ -129,7 +129,7 @@ public class ConsultationService {
     }
 
     @Transactional(readOnly = true)
-    public List<ConsultationResponseDto> findByTitleContaining(String keyword, LocalDate startDate,
+    public List<ConsultationResponseDto> findByTitle(String keyword, LocalDate startDate,
                                                                LocalDate endDate, Long userId) {
         LocalDateTime startOfDay = DateUtils.getStartOfDay(startDate);
         LocalDateTime endOfDay = DateUtils.getEndOfDay(endDate);
@@ -141,7 +141,7 @@ public class ConsultationService {
     }
 
     @Transactional(readOnly = true)
-    public List<ConsultationResponseDto> findByContentsContaining(String keyword, LocalDate startDate,
+    public List<ConsultationResponseDto> findByContents(String keyword, LocalDate startDate,
                                                                   LocalDate endDate, Long userId) {
         LocalDateTime startOfDay = DateUtils.getStartOfDay(startDate);
         LocalDateTime endOfDay = DateUtils.getEndOfDay(endDate);

--- a/src/main/java/com/example/tnote/boundedContext/observation/exception/ObservationErrorCode.java
+++ b/src/main/java/com/example/tnote/boundedContext/observation/exception/ObservationErrorCode.java
@@ -1,0 +1,24 @@
+package com.example.tnote.boundedContext.observation.exception;
+
+import com.example.tnote.base.exception.ErrorCode;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum ObservationErrorCode implements ErrorCode {
+    OBSERVATION_NOT_FOUNT(HttpStatus.NOT_FOUND, "not found observation"),
+    INVALID_OBSERVATION_DATA(HttpStatus.BAD_REQUEST, "Invalid observation data"),
+    INVALID_OBSERVATION_DATE(HttpStatus.BAD_REQUEST, "Observation date must be within the schedule dates");
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    ObservationErrorCode(final HttpStatus httpStatus, final String message) {
+        this.httpStatus = httpStatus;
+        this.message = message;
+    }
+
+    @Override
+    public String getCode() {
+        return "";
+    }
+}

--- a/src/main/java/com/example/tnote/boundedContext/observation/exception/ObservationException.java
+++ b/src/main/java/com/example/tnote/boundedContext/observation/exception/ObservationException.java
@@ -1,0 +1,10 @@
+package com.example.tnote.boundedContext.observation.exception;
+
+import com.example.tnote.base.exception.CustomException;
+import com.example.tnote.base.exception.ErrorCode;
+
+public class ObservationException extends CustomException {
+    public ObservationException(final ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/example/tnote/boundedContext/proceeding/exception/ProceedingErrorCode.java
+++ b/src/main/java/com/example/tnote/boundedContext/proceeding/exception/ProceedingErrorCode.java
@@ -6,6 +6,10 @@ import org.springframework.http.HttpStatus;
 
 @Getter
 public enum ProceedingErrorCode implements ErrorCode {
+    PROCEEDING_NOT_FOUNT(HttpStatus.NOT_FOUND, "업무일지를 찾을 수 없습니다."),
+    INVALID_PROCEEDING_DATE(HttpStatus.BAD_REQUEST, "해당 업무일지 내의 기간이 아닙니다."),
+    INVALID_PROCEEDING_DATA(HttpStatus.BAD_REQUEST, "업무일지에 적합한 내용이 아닙니다.")
+    ;
     private final HttpStatus httpStatus;
     private final String message;
 

--- a/src/main/java/com/example/tnote/boundedContext/proceeding/exception/ProceedingErrorCode.java
+++ b/src/main/java/com/example/tnote/boundedContext/proceeding/exception/ProceedingErrorCode.java
@@ -1,0 +1,21 @@
+package com.example.tnote.boundedContext.proceeding.exception;
+
+import com.example.tnote.base.exception.ErrorCode;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum ProceedingErrorCode implements ErrorCode {
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    ProceedingErrorCode(final HttpStatus httpStatus, final String message) {
+        this.httpStatus = httpStatus;
+        this.message = message;
+    }
+
+    @Override
+    public String getCode() {
+        return "";
+    }
+}

--- a/src/main/java/com/example/tnote/boundedContext/proceeding/exception/ProceedingException.java
+++ b/src/main/java/com/example/tnote/boundedContext/proceeding/exception/ProceedingException.java
@@ -1,0 +1,10 @@
+package com.example.tnote.boundedContext.proceeding.exception;
+
+import com.example.tnote.base.exception.CustomException;
+import com.example.tnote.base.exception.ErrorCode;
+
+public class ProceedingException extends CustomException {
+    public ProceedingException(final ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/example/tnote/boundedContext/schedule/exception/ScheduleErrorCode.java
+++ b/src/main/java/com/example/tnote/boundedContext/schedule/exception/ScheduleErrorCode.java
@@ -7,7 +7,8 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum ScheduleErrorCode implements ErrorCode {
     SCHEDULE_NOT_FOUND(HttpStatus.NOT_FOUND, "schedule를 찾을 수 없습니다."),
-    INVALID_SCHEDULE(HttpStatus.BAD_REQUEST, "유효한 학기가 아닙니다.");
+    INVALID_SCHEDULE(HttpStatus.BAD_REQUEST, "유효한 학기가 아닙니다."),
+    DATES_NOT_INCLUDED_IN_SEMESTER(HttpStatus.NOT_FOUND, "해당 학기의 기간이 아닙니다."),;
     private final HttpStatus httpStatus;
     private final String message;
 

--- a/src/test/java/com/example/tnote/consultation/ConsultationServiceTest.java
+++ b/src/test/java/com/example/tnote/consultation/ConsultationServiceTest.java
@@ -1,15 +1,12 @@
 package com.example.tnote.consultation;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.example.tnote.base.exception.CustomExceptions;
 import com.example.tnote.boundedContext.consultation.dto.ConsultationDeleteResponseDto;
 import com.example.tnote.boundedContext.consultation.dto.ConsultationDetailResponseDto;
 import com.example.tnote.boundedContext.consultation.dto.ConsultationRequestDto;
@@ -20,6 +17,7 @@ import com.example.tnote.boundedContext.consultation.entity.Consultation;
 import com.example.tnote.boundedContext.consultation.entity.ConsultationImage;
 import com.example.tnote.boundedContext.consultation.entity.CounselingField;
 import com.example.tnote.boundedContext.consultation.entity.CounselingType;
+import com.example.tnote.boundedContext.consultation.exception.ConsultationException;
 import com.example.tnote.boundedContext.consultation.repository.ConsultationImageRepository;
 import com.example.tnote.boundedContext.consultation.repository.ConsultationRepository;
 import com.example.tnote.boundedContext.consultation.service.ConsultationService;
@@ -28,12 +26,14 @@ import com.example.tnote.boundedContext.schedule.entity.Schedule;
 import com.example.tnote.boundedContext.schedule.repository.ScheduleRepository;
 import com.example.tnote.boundedContext.user.entity.User;
 import com.example.tnote.boundedContext.user.repository.UserRepository;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -62,20 +62,37 @@ public class ConsultationServiceTest {
     @InjectMocks
     private ConsultationService consultationService;
 
+    private User mockUser;
+    private Schedule mockSchedule;
+    private Consultation mockConsultation;
+    private Long userId = 1L;
+    private Long scheduleId = 2L;
+    private Long consultationId = 1L;
+
+    @BeforeEach
+    void setUp() {
+        mockUser = mock(User.class);
+        mockSchedule = new Schedule(1L, "1학기", null,
+                LocalDate.of(2024, 1, 1),
+                LocalDate.of(2024, 3, 28),
+                mockUser,
+                new ArrayList<>(),
+                new ArrayList<>(),
+                new ArrayList<>(),
+                new ArrayList<>(),
+                new ArrayList<>(),
+                new ArrayList<>());
+
+        mockConsultation = mock(Consultation.class);
+    }
+
     @DisplayName("상담일지 저장: 정상적인 경우 성공적으로 저장 확인")
     @Test
     void save() {
-        Long userId = 1L;
-        Long scheduleId = 2L;
-        User mockUser = mock(User.class);
-        Schedule mockSchedule = mock(Schedule.class);
-
-        LocalDateTime now = LocalDateTime.now();
-
         ConsultationRequestDto requestDto = ConsultationRequestDto.builder()
                 .title("김태")
-                .startDate(now)
-                .endDate(now.plusHours(2))
+                .startDate(mockSchedule.getStartDate().atStartOfDay())
+                .endDate(mockSchedule.getStartDate().atStartOfDay().plusHours(2))
                 .counselingField(CounselingField.FRIENDSHIP)
                 .counselingType(CounselingType.STUDENT)
                 .consultationContents("상담내용")
@@ -99,14 +116,10 @@ public class ConsultationServiceTest {
     @DisplayName("상담일지 저장: 올바르지 않은 상수가 입력되었을 때 예외 발생 확인")
     @Test
     void saveWithInvalidEnums() {
-        Long userId = 1L;
-        Long scheduleId = 2L;
-        LocalDateTime now = LocalDateTime.now();
-
         ConsultationRequestDto requestDto = ConsultationRequestDto.builder()
                 .title("김태")
-                .startDate(now)
-                .endDate(now.plusHours(2))
+                .startDate(mockSchedule.getStartDate().atStartOfDay())
+                .endDate(mockSchedule.getStartDate().atStartOfDay().plusHours(2))
                 .counselingField(null)
                 .counselingType(null)
                 .consultationContents("상담내용")
@@ -115,24 +128,7 @@ public class ConsultationServiceTest {
                 .build();
 
         assertThatThrownBy(() -> consultationService.save(userId, scheduleId, requestDto, Collections.emptyList()))
-                .isInstanceOf(CustomExceptions.class);
-    }
-
-    @DisplayName("상담일지 저장: 존재하지 않는 사용자로 인한 예외 발생 확인")
-    @Test
-    void noUserSave() {
-        Long userId = 1L;
-        Long scheduleId = 2L;
-        ConsultationRequestDto requestDto = mock(ConsultationRequestDto.class);
-        List<MultipartFile> consultationImages = Collections.emptyList();
-
-        when(userRepository.findById(userId)).thenReturn(Optional.empty());
-
-        assertThatExceptionOfType(CustomExceptions.class)
-                .isThrownBy(() -> consultationService.save(userId, scheduleId, requestDto, consultationImages));
-
-        verify(userRepository).findById(userId);
-        verify(consultationRepository, never()).save(any(Consultation.class));
+                .isInstanceOf(ConsultationException.class);
     }
 
     @DisplayName("상담일지 조회: 작성자가 작성한 모든 상담일지 조회 확인")
@@ -161,16 +157,10 @@ public class ConsultationServiceTest {
     @DisplayName("상담일지 상세 조회: 상담일지 상세 정보 조회 확인")
     @Test
     void getConsultationDetails() {
-        Long userId = 1L;
-        Long consultationId = 1L;
-
-        User mockUser = mock(User.class);
         when(mockUser.getId()).thenReturn(userId);
-
-        Consultation mockConsultation = mock(Consultation.class);
         when(mockConsultation.getId()).thenReturn(consultationId);
         when(mockConsultation.getUser()).thenReturn(mockUser);
-
+        when(mockConsultation.getSchedule()).thenReturn(mockSchedule);
         List<ConsultationImage> mockClassLogImages = new ArrayList<>();
 
         when(consultationRepository.findByIdAndUserId(consultationId, userId)).thenReturn(
@@ -192,31 +182,21 @@ public class ConsultationServiceTest {
     @DisplayName("존재하지 않는 상담일지의 상세정보 조회 시 예외 발생")
     @Test
     void getConsultationDetailException() {
-        Long userId = 1L;
         Long consultationId = 100L;
 
         when(consultationRepository.findByIdAndUserId(consultationId, userId)).thenReturn(Optional.empty());
 
         assertThatThrownBy(() -> consultationService.getConsultationDetail(userId, consultationId))
-                .isInstanceOf(CustomExceptions.class);
+                .isInstanceOf(ConsultationException.class);
     }
 
     @DisplayName("상담일지 삭제: 상담일지 삭제 작업 확인")
     @Test
     void deleteConsultation() {
-        Long userId = 1L;
-        Long consultationId = 1L;
-
-        Consultation mockConsultation = mock(Consultation.class);
-        when(mockConsultation.getId()).thenReturn(consultationId);
-
         when(consultationRepository.findByIdAndUserId(consultationId, userId)).thenReturn(
                 Optional.of(mockConsultation));
 
         ConsultationDeleteResponseDto result = consultationService.deleteConsultation(userId, consultationId);
-
-        assertThat(result).isNotNull();
-        assertThat(result.getId()).isEqualTo(consultationId);
 
         verify(consultationRepository).findByIdAndUserId(userId, consultationId);
         verify(consultationRepository).delete(mockConsultation);
@@ -225,9 +205,8 @@ public class ConsultationServiceTest {
     @DisplayName("상담일지 수정: 요청된 값에 따른 상담일지 수정 확인")
     @Test
     void updateConsultation() {
-        Long userId = 1L;
-        Long consultationId = 1L;
-        Consultation mockConsultation = mock(Consultation.class);
+        when(mockConsultation.getId()).thenReturn(consultationId);
+        when(mockConsultation.getSchedule()).thenReturn(mockSchedule);
         ConsultationUpdateRequestDto classLogUpdateRequestDto = mock(ConsultationUpdateRequestDto.class);
         List<MultipartFile> consultationImages = Collections.emptyList();
 

--- a/src/test/java/com/example/tnote/proceeding/ProceedingServiceTest.java
+++ b/src/test/java/com/example/tnote/proceeding/ProceedingServiceTest.java
@@ -1,15 +1,12 @@
 package com.example.tnote.proceeding;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.example.tnote.base.exception.CustomExceptions;
 import com.example.tnote.boundedContext.proceeding.dto.ProceedingDeleteResponseDto;
 import com.example.tnote.boundedContext.proceeding.dto.ProceedingDetailResponseDto;
 import com.example.tnote.boundedContext.proceeding.dto.ProceedingRequestDto;
@@ -18,6 +15,7 @@ import com.example.tnote.boundedContext.proceeding.dto.ProceedingSliceResponseDt
 import com.example.tnote.boundedContext.proceeding.dto.ProceedingUpdateRequestDto;
 import com.example.tnote.boundedContext.proceeding.entity.Proceeding;
 import com.example.tnote.boundedContext.proceeding.entity.ProceedingImage;
+import com.example.tnote.boundedContext.proceeding.exception.ProceedingException;
 import com.example.tnote.boundedContext.proceeding.repository.ProceedingImageRepository;
 import com.example.tnote.boundedContext.proceeding.repository.ProceedingRepository;
 import com.example.tnote.boundedContext.proceeding.service.ProceedingService;
@@ -26,11 +24,13 @@ import com.example.tnote.boundedContext.schedule.entity.Schedule;
 import com.example.tnote.boundedContext.schedule.repository.ScheduleRepository;
 import com.example.tnote.boundedContext.user.entity.User;
 import com.example.tnote.boundedContext.user.repository.UserRepository;
-import java.time.LocalDateTime;
+import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -59,21 +59,38 @@ public class ProceedingServiceTest {
     @InjectMocks
     private ProceedingService proceedingService;
 
+    private User mockUser;
+    private Schedule mockSchedule;
+    private Proceeding mockProceeding;
+    private Long userId = 1L;
+    private Long scheduleId = 2L;
+    private Long proceedingId = 1L;
+
+    @BeforeEach
+    void setUp() {
+        mockUser = mock(User.class);
+        mockSchedule = new Schedule(1L, "1학기", null,
+                LocalDate.of(2024, 1, 1),
+                LocalDate.of(2024, 3, 28),
+                mockUser,
+                new ArrayList<>(),
+                new ArrayList<>(),
+                new ArrayList<>(),
+                new ArrayList<>(),
+                new ArrayList<>(),
+                new ArrayList<>());
+
+        mockProceeding = mock(Proceeding.class);
+    }
 
     @DisplayName("업무일지 저장: 정상적인 경우 성공적으로 저장 확인")
     @Test
     void save() {
-        Long userId = 1L;
-        Long scheduleId = 2L;
-        User mockUser = mock(User.class);
-        Schedule mockSchedule = mock(Schedule.class);
-
-        LocalDateTime now = LocalDateTime.now();
 
         ProceedingRequestDto requestDto = ProceedingRequestDto.builder()
                 .title("테스트 수업 로그")
-                .startDate(now)
-                .endDate(now.plusHours(2))
+                .startDate(mockSchedule.getStartDate().atStartOfDay())
+                .endDate(mockSchedule.getStartDate().atStartOfDay().plusHours(2))
                 .location("부산")
                 .workContents("사진찍기")
                 .isAllDay(false)
@@ -91,28 +108,9 @@ public class ProceedingServiceTest {
         verify(proceedingRepository).save(any(Proceeding.class));
     }
 
-    @DisplayName("업무일지 저장: 존재하지 않는 사용자로 인한 예외 발생 확인")
-    @Test
-    void noUserSave() {
-        Long userId = 1L;
-        Long scheduleId = 2L;
-        ProceedingRequestDto requestDto = mock(ProceedingRequestDto.class);
-        List<MultipartFile> proceedingImages = Collections.emptyList();
-
-        when(userRepository.findById(userId)).thenReturn(Optional.empty());
-
-        assertThatExceptionOfType(CustomExceptions.class)
-                .isThrownBy(() -> proceedingService.save(userId, scheduleId, requestDto, proceedingImages));
-
-        verify(userRepository).findById(userId);
-        verify(proceedingRepository, never()).save(any(Proceeding.class));
-    }
-
     @DisplayName("업무일지 조회: 작성자가 작성한 모든 업무일지 조회 확인")
     @Test
     void getProceedings() {
-        Long userId = 1L;
-        Long scheduleId = 2L;
         Pageable pageable = PageRequest.of(0, 10);
 
         Proceeding mockProceeding1 = mock(Proceeding.class);
@@ -133,14 +131,9 @@ public class ProceedingServiceTest {
     @DisplayName("업무일지 상세 조회: 업무일지 상세 정보 조회 확인")
     @Test
     void getProceedingDetails() {
-        Long userId = 1L;
-        Long proceedingId = 1L;
-
-        User mockUser = mock(User.class);
         when(mockUser.getId()).thenReturn(userId);
-
-        Proceeding mockProceeding = mock(Proceeding.class);
         when(mockProceeding.getId()).thenReturn(proceedingId);
+        when(mockProceeding.getSchedule()).thenReturn(mockSchedule);
         when(mockProceeding.getUser()).thenReturn(mockUser);
 
         ProceedingImage mockProceedingImage = mock(ProceedingImage.class);
@@ -165,30 +158,21 @@ public class ProceedingServiceTest {
     @DisplayName("존재하지 않는 업무일지의 상세정보 조회 시 예외 발생")
     @Test
     void getClassLogDetailException() {
-        Long userId = 1L;
         Long proceedingId = 100L;
 
         when(proceedingRepository.findByIdAndUserId(proceedingId, userId)).thenReturn(Optional.empty());
 
         assertThatThrownBy(() -> proceedingService.getProceedingDetails(userId, proceedingId))
-                .isInstanceOf(CustomExceptions.class);
+                .isInstanceOf(ProceedingException.class);
     }
 
     @DisplayName("업무일지 삭제: 업무일지 삭제 작업 확인")
     @Test
     void deleteProceeding() {
-        Long userId = 1L;
-        Long proceedingId = 1L;
-
-        Proceeding mockProceeding = mock(Proceeding.class);
         when(mockProceeding.getId()).thenReturn(proceedingId);
-
         when(proceedingRepository.findByIdAndUserId(userId, proceedingId)).thenReturn(Optional.of(mockProceeding));
 
         ProceedingDeleteResponseDto result = proceedingService.deleteProceeding(userId, proceedingId);
-
-        assertThat(result).isNotNull();
-        assertThat(result.getId()).isEqualTo(proceedingId);
 
         verify(proceedingRepository).findByIdAndUserId(userId, proceedingId);
         verify(proceedingRepository).delete(mockProceeding);
@@ -197,13 +181,11 @@ public class ProceedingServiceTest {
     @DisplayName("업무일지 수정: 요청된 값에 따른 업무일지 수정 확인")
     @Test
     void updateClassLog() {
-        Long userId = 1L;
-        Long proceedingId = 1L;
-        Proceeding mockProceeding = mock(Proceeding.class);
         ProceedingUpdateRequestDto proceedingUpdateRequestDto = mock(ProceedingUpdateRequestDto.class);
         List<MultipartFile> proceedingImages = Collections.emptyList();
 
         when(proceedingRepository.findByIdAndUserId(userId, proceedingId)).thenReturn(Optional.of(mockProceeding));
+        when(mockProceeding.getSchedule()).thenReturn(mockSchedule);
 
         ProceedingResponseDto result = proceedingService.updateProceeding(userId, proceedingId,
                 proceedingUpdateRequestDto,


### PR DESCRIPTION
## #️⃣연관된 이슈

close #211 

## 📝작업 내용

- 모든일지 예외클래스 작성 및 에러메시지 enum 클래스로 분리
- 분리한 예외클래스 사용한 테스트 코드 수정
- 상담일지 url 경로 수정
- 상담일지 관련 메소드 명 수정


## ✅테스트 결과

<img width="432" alt="image" src="https://github.com/user-attachments/assets/1816d316-8813-4545-b4f4-35b66da6790f">
