### PR TITLE
일정 조회 및 삭제 api 구현

### DIFF
--- a/src/main/java/com/example/tnote/boundedContext/plan/controller/PlanController.java
+++ b/src/main/java/com/example/tnote/boundedContext/plan/controller/PlanController.java
@@ -39,9 +39,9 @@ public class PlanController {
                 Result.of(planService.save(principalDetails.getId(), scheduleId, planSaveRequest, planImages)));
     }
 
-    @GetMapping(value = "/{scheduleId}/all")
+    @GetMapping(value = "/all")
     public ResponseEntity<Result> findAll(@AuthenticationPrincipal final PrincipalDetails principalDetails,
-                                          @PathVariable final Long scheduleId,
+                                          @RequestParam final Long scheduleId,
                                           @RequestParam(value = "page", required = false, defaultValue = "0") int page,
                                           @RequestParam(value = "size", required = false, defaultValue = "4") int size) {
 

--- a/src/main/java/com/example/tnote/boundedContext/plan/controller/PlanController.java
+++ b/src/main/java/com/example/tnote/boundedContext/plan/controller/PlanController.java
@@ -9,6 +9,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -48,4 +49,9 @@ public class PlanController {
         return ResponseEntity.ok(Result.of(planService.findAll(principalDetails.getId(), scheduleId, pageRequest)));
     }
 
+    @DeleteMapping(value = "/{scheduleId}")
+    public ResponseEntity<Result> delete(@AuthenticationPrincipal final PrincipalDetails principalDetails,
+                                         @RequestParam final Long planId) {
+        return ResponseEntity.ok(Result.of(planService.delete(principalDetails.getId(), planId)));
+    }
 }

--- a/src/main/java/com/example/tnote/boundedContext/plan/controller/PlanController.java
+++ b/src/main/java/com/example/tnote/boundedContext/plan/controller/PlanController.java
@@ -29,14 +29,27 @@ public class PlanController {
         this.planService = planService;
     }
 
-    @PostMapping(value = "/{scheduleId}", consumes = {MediaType.APPLICATION_JSON_VALUE,
+    @PostMapping(consumes = {MediaType.APPLICATION_JSON_VALUE,
             MediaType.MULTIPART_FORM_DATA_VALUE})
     public ResponseEntity<Result> save(@AuthenticationPrincipal final PrincipalDetails principalDetails,
-                                       @PathVariable final Long scheduleId,
+                                       @RequestParam final Long scheduleId,
                                        @RequestPart final PlanSaveRequest planSaveRequest,
                                        @RequestPart(name = "planImages", required = false) final List<MultipartFile> planImages) {
         return ResponseEntity.ok(
                 Result.of(planService.save(principalDetails.getId(), scheduleId, planSaveRequest, planImages)));
+    }
+
+    @GetMapping
+    public ResponseEntity<Result> find(@AuthenticationPrincipal final PrincipalDetails principalDetails,
+                                       @RequestParam final Long planId) {
+
+        return ResponseEntity.ok(Result.of(planService.find(principalDetails.getId(), planId)));
+    }
+
+    @DeleteMapping
+    public ResponseEntity<Result> delete(@AuthenticationPrincipal final PrincipalDetails principalDetails,
+                                         @RequestParam final Long planId) {
+        return ResponseEntity.ok(Result.of(planService.delete(principalDetails.getId(), planId)));
     }
 
     @GetMapping(value = "/all")
@@ -47,11 +60,5 @@ public class PlanController {
 
         PageRequest pageRequest = PageRequest.of(page, size);
         return ResponseEntity.ok(Result.of(planService.findAll(principalDetails.getId(), scheduleId, pageRequest)));
-    }
-
-    @DeleteMapping()
-    public ResponseEntity<Result> delete(@AuthenticationPrincipal final PrincipalDetails principalDetails,
-                                         @RequestParam final Long planId) {
-        return ResponseEntity.ok(Result.of(planService.delete(principalDetails.getId(), planId)));
     }
 }

--- a/src/main/java/com/example/tnote/boundedContext/plan/controller/PlanController.java
+++ b/src/main/java/com/example/tnote/boundedContext/plan/controller/PlanController.java
@@ -5,12 +5,15 @@ import com.example.tnote.boundedContext.plan.dto.PlanSaveRequest;
 import com.example.tnote.boundedContext.plan.service.PlanService;
 import com.example.tnote.boundedContext.user.entity.auth.PrincipalDetails;
 import java.util.List;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
@@ -33,6 +36,16 @@ public class PlanController {
                                        @RequestPart(name = "planImages", required = false) final List<MultipartFile> planImages) {
         return ResponseEntity.ok(
                 Result.of(planService.save(principalDetails.getId(), scheduleId, planSaveRequest, planImages)));
+    }
+
+    @GetMapping(value = "/{scheduleId}/all")
+    public ResponseEntity<Result> findAll(@AuthenticationPrincipal final PrincipalDetails principalDetails,
+                                          @PathVariable final Long scheduleId,
+                                          @RequestParam(value = "page", required = false, defaultValue = "0") int page,
+                                          @RequestParam(value = "size", required = false, defaultValue = "4") int size) {
+
+        PageRequest pageRequest = PageRequest.of(page, size);
+        return ResponseEntity.ok(Result.of(planService.findAll(principalDetails.getId(), scheduleId, pageRequest)));
     }
 
 }

--- a/src/main/java/com/example/tnote/boundedContext/plan/controller/PlanController.java
+++ b/src/main/java/com/example/tnote/boundedContext/plan/controller/PlanController.java
@@ -49,7 +49,7 @@ public class PlanController {
         return ResponseEntity.ok(Result.of(planService.findAll(principalDetails.getId(), scheduleId, pageRequest)));
     }
 
-    @DeleteMapping(value = "/{scheduleId}")
+    @DeleteMapping()
     public ResponseEntity<Result> delete(@AuthenticationPrincipal final PrincipalDetails principalDetails,
                                          @RequestParam final Long planId) {
         return ResponseEntity.ok(Result.of(planService.delete(principalDetails.getId(), planId)));

--- a/src/main/java/com/example/tnote/boundedContext/plan/dto/PlanDeleteResponse.java
+++ b/src/main/java/com/example/tnote/boundedContext/plan/dto/PlanDeleteResponse.java
@@ -10,7 +10,7 @@ public class PlanDeleteResponse {
     public PlanDeleteResponse() {
     }
 
-    public PlanDeleteResponse(Long id) {
-        this.id = id;
+    public PlanDeleteResponse(final Plan plan) {
+        this.id = plan.getId();
     }
 }

--- a/src/main/java/com/example/tnote/boundedContext/plan/dto/PlanDeleteResponse.java
+++ b/src/main/java/com/example/tnote/boundedContext/plan/dto/PlanDeleteResponse.java
@@ -1,0 +1,16 @@
+package com.example.tnote.boundedContext.plan.dto;
+
+import com.example.tnote.boundedContext.plan.entity.Plan;
+import lombok.Getter;
+
+@Getter
+public class PlanDeleteResponse {
+    private Long id;
+
+    public PlanDeleteResponse() {
+    }
+
+    public PlanDeleteResponse(Long id) {
+        this.id = id;
+    }
+}

--- a/src/main/java/com/example/tnote/boundedContext/plan/dto/PlanResponses.java
+++ b/src/main/java/com/example/tnote/boundedContext/plan/dto/PlanResponses.java
@@ -1,0 +1,37 @@
+package com.example.tnote.boundedContext.plan.dto;
+
+import com.example.tnote.boundedContext.plan.entity.Plan;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.domain.Slice;
+
+@Getter
+@Builder
+public class PlanResponses {
+    private List<PlanResponse> plans;
+    private int numberOfClassLog;
+    private long page;
+    @JsonProperty(value = "isLast")
+    private Boolean isLast;
+
+    public PlanResponses() {
+    }
+
+    public PlanResponses(List<PlanResponse> plans, int numberOfClassLog, long page, Boolean isLast) {
+        this.plans = plans;
+        this.numberOfClassLog = numberOfClassLog;
+        this.page = page;
+        this.isLast = isLast;
+    }
+
+    public static PlanResponses of(final List<PlanResponse> planResponses, final List<Plan> plans, Slice<Plan> slice) {
+        return PlanResponses.builder()
+                .plans(planResponses)
+                .numberOfClassLog(plans.size())
+                .page(slice.getPageable().getPageNumber())
+                .isLast(slice.isLast())
+                .build();
+    }
+}

--- a/src/main/java/com/example/tnote/boundedContext/plan/exception/PlanErrorCode.java
+++ b/src/main/java/com/example/tnote/boundedContext/plan/exception/PlanErrorCode.java
@@ -7,6 +7,7 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum PlanErrorCode implements ErrorCode {
 
+    NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 일정입니다."),
     INVALID_PLAN_DATE(HttpStatus.BAD_REQUEST, "해당 기간에 일치하는 일정이 존재하지 않습니다.");
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/example/tnote/boundedContext/plan/repository/PlanImageRepository.java
+++ b/src/main/java/com/example/tnote/boundedContext/plan/repository/PlanImageRepository.java
@@ -1,7 +1,13 @@
 package com.example.tnote.boundedContext.plan.repository;
 
 import com.example.tnote.boundedContext.plan.entity.PlanImage;
+import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 public interface PlanImageRepository extends JpaRepository<PlanImage, Long> {
+    @Modifying
+    @Query("DELETE FROM PlanImage p WHERE p.plan.id = :planId")
+    void deleteByPlanId(@Param("planId") Long planId);
 }

--- a/src/main/java/com/example/tnote/boundedContext/plan/repository/PlanRepository.java
+++ b/src/main/java/com/example/tnote/boundedContext/plan/repository/PlanRepository.java
@@ -2,12 +2,17 @@ package com.example.tnote.boundedContext.plan.repository;
 
 import com.example.tnote.boundedContext.plan.entity.Plan;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 public interface PlanRepository extends JpaRepository<Plan, Long> {
+
+    @Query("select p from Plan p where p.id = :id and p.user.id = :userId")
+    Optional<Plan> findByIdAndUserId(Long id , Long userId);
+
     @Query("select p from Plan p where p.user.id = :userId and p.schedule.id = :scheduleId")
     List<Plan> findALLByUserIdAndScheduleId(Long userId, Long scheduleId);
 

--- a/src/main/java/com/example/tnote/boundedContext/plan/repository/PlanRepository.java
+++ b/src/main/java/com/example/tnote/boundedContext/plan/repository/PlanRepository.java
@@ -1,7 +1,11 @@
 package com.example.tnote.boundedContext.plan.repository;
 
 import com.example.tnote.boundedContext.plan.entity.Plan;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface PlanRepository extends JpaRepository<Plan, Long> {
+    @Query("select p from Plan p where p.user.id = :userId and p.schedule.id = :scheduleId")
+    List<Plan> findByUserIdAndScheduleId(Long userId, Long scheduleId);
 }

--- a/src/main/java/com/example/tnote/boundedContext/plan/repository/PlanRepository.java
+++ b/src/main/java/com/example/tnote/boundedContext/plan/repository/PlanRepository.java
@@ -2,10 +2,15 @@ package com.example.tnote.boundedContext.plan.repository;
 
 import com.example.tnote.boundedContext.plan.entity.Plan;
 import java.util.List;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 public interface PlanRepository extends JpaRepository<Plan, Long> {
     @Query("select p from Plan p where p.user.id = :userId and p.schedule.id = :scheduleId")
-    List<Plan> findByUserIdAndScheduleId(Long userId, Long scheduleId);
+    List<Plan> findALLByUserIdAndScheduleId(Long userId, Long scheduleId);
+
+    @Query("select p from Plan p where p.user.id = :userId and p.schedule.id = :scheduleId ORDER BY p.createdAt DESC")
+    Slice<Plan> findALLByUserIdAndScheduleId(Long userId, Long scheduleId, Pageable pageable);
 }

--- a/src/main/java/com/example/tnote/boundedContext/plan/service/PlanService.java
+++ b/src/main/java/com/example/tnote/boundedContext/plan/service/PlanService.java
@@ -78,7 +78,7 @@ public class PlanService {
         deleteExistedImage(plan);
         planRepository.delete(plan);
 
-        return new PlanDeleteResponse(plan.getId());
+        return new PlanDeleteResponse(plan);
     }
 
     private List<PlanImage> uploadPlanImages(Plan plan, List<MultipartFile> planImages) {

--- a/src/main/java/com/example/tnote/boundedContext/plan/service/PlanService.java
+++ b/src/main/java/com/example/tnote/boundedContext/plan/service/PlanService.java
@@ -76,6 +76,7 @@ public class PlanService {
         Plan plan = planRepository.findByIdAndUserId(planId, userId)
                 .orElseThrow(() -> new PlanException(PlanErrorCode.NOT_FOUND));
         deleteExistedImage(plan);
+        planRepository.delete(plan);
 
         return new PlanDeleteResponse(plan.getId());
     }

--- a/src/main/java/com/example/tnote/boundedContext/plan/service/PlanService.java
+++ b/src/main/java/com/example/tnote/boundedContext/plan/service/PlanService.java
@@ -97,7 +97,6 @@ public class PlanService {
     private void deleteExistedImage(Plan plan) {
         System.out.println("Deleting existing images for plan ID: " + plan.getId());
         deleteS3Images(plan);
-        planImageRepository.deleteByPlanId(plan.getId());
     }
 
     private void deleteS3Images(Plan plan) {

--- a/src/main/java/com/example/tnote/boundedContext/plan/service/PlanService.java
+++ b/src/main/java/com/example/tnote/boundedContext/plan/service/PlanService.java
@@ -1,8 +1,6 @@
 package com.example.tnote.boundedContext.plan.service;
 
 import com.example.tnote.base.utils.AwsS3Uploader;
-import com.example.tnote.boundedContext.classLog.entity.ClassLog;
-import com.example.tnote.boundedContext.classLog.entity.ClassLogImage;
 import com.example.tnote.boundedContext.plan.dto.PlanDeleteResponse;
 import com.example.tnote.boundedContext.plan.dto.PlanResponses;
 import com.example.tnote.boundedContext.plan.dto.PlanSaveRequest;

--- a/src/main/java/com/example/tnote/boundedContext/plan/service/PlanService.java
+++ b/src/main/java/com/example/tnote/boundedContext/plan/service/PlanService.java
@@ -42,7 +42,7 @@ public class PlanService {
 
     @Transactional
     public PlanResponse save(final Long userId, final Long scheduleId, final PlanSaveRequest registerRequest,
-                             List<MultipartFile> planImages) {
+                             final List<MultipartFile> planImages) {
         User user = userRepository.findUserById(userId);
         Schedule schedule = scheduleRepository.findScheduleById(scheduleId);
         Plan plan = registerRequest.toEntity(user, schedule);

--- a/src/main/java/com/example/tnote/boundedContext/plan/service/PlanService.java
+++ b/src/main/java/com/example/tnote/boundedContext/plan/service/PlanService.java
@@ -73,12 +73,16 @@ public class PlanService {
 
     @Transactional
     public PlanDeleteResponse delete(final Long planId, final Long userId) {
-        Plan plan = planRepository.findByIdAndUserId(planId, userId)
-                .orElseThrow(() -> new PlanException(PlanErrorCode.NOT_FOUND));
+        Plan plan = findByIdAndUserId(planId, userId);
         deleteExistedImage(plan);
         planRepository.delete(plan);
 
         return new PlanDeleteResponse(plan);
+    }
+
+    public PlanResponse find(final Long userId, final Long planId) {
+        Plan plan = findByIdAndUserId(planId, userId);
+        return PlanResponse.from(plan);
     }
 
     private List<PlanImage> uploadPlanImages(Plan plan, List<MultipartFile> planImages) {
@@ -113,5 +117,10 @@ public class PlanService {
         return planSlice.getContent().stream()
                 .map(PlanResponse::from)
                 .toList();
+    }
+
+    private Plan findByIdAndUserId(Long planId, Long userId) {
+        return planRepository.findByIdAndUserId(planId, userId)
+                .orElseThrow(() -> new PlanException(PlanErrorCode.NOT_FOUND));
     }
 }

--- a/src/test/java/com/example/tnote/plan/service/PlanServiceTest.java
+++ b/src/test/java/com/example/tnote/plan/service/PlanServiceTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -13,6 +14,7 @@ import com.example.tnote.boundedContext.plan.dto.PlanDeleteResponse;
 import com.example.tnote.boundedContext.plan.dto.PlanResponse;
 import com.example.tnote.boundedContext.plan.dto.PlanSaveRequest;
 import com.example.tnote.boundedContext.plan.entity.Plan;
+import com.example.tnote.boundedContext.plan.exception.PlanException;
 import com.example.tnote.boundedContext.plan.repository.PlanRepository;
 import com.example.tnote.boundedContext.plan.service.PlanService;
 import com.example.tnote.boundedContext.schedule.entity.Schedule;
@@ -96,5 +98,22 @@ class PlanServiceTest {
             assertThat(response.getId()).isEqualTo(plan.getId());
             verify(planRepository).delete(plan);
         }
+
+
+        @Test
+        @DisplayName("존재하지 않는 일정 삭제 시 예외")
+        void deleteNotExist() {
+            Long planId = 12L;
+            Long userId = 1L;
+
+            when(planRepository.findByIdAndUserId(planId, userId)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> {
+                planService.delete(planId, userId);
+            }).isInstanceOf(PlanException.class);
+
+            verify(planRepository, never()).delete(any(Plan.class));
+        }
+
     }
 }

--- a/src/test/java/com/example/tnote/plan/service/PlanServiceTest.java
+++ b/src/test/java/com/example/tnote/plan/service/PlanServiceTest.java
@@ -126,6 +126,7 @@ class PlanServiceTest {
     @Nested
     class find {
         User user = mock(User.class);
+        User user2 = mock(User.class);
         LocalDate startDate = LocalDate.of(2024, 1, 10);
         LocalDate endDate = LocalDate.of(2024, 1, 20);
         Schedule schedule = new Schedule(1L, "1학기", null,
@@ -138,12 +139,14 @@ class PlanServiceTest {
             Long scheduleId = 1L;
             Pageable pageable = PageRequest.of(0, 10);
             List<Plan> mockPlans = Arrays.asList(
-                    new Plan("Development", LocalDateTime.now(), LocalDateTime.now().plusDays(1), "Seoul", "Project Development", "Team", user, schedule, new ArrayList<>()),
-                    new Plan("Meeting", LocalDateTime.now(), LocalDateTime.now().plusHours(1), "Busan", "Team Meeting", "Staff", user, schedule, new ArrayList<>())
+                    new Plan("Development", LocalDateTime.now(), LocalDateTime.now().plusDays(1), "Seoul",
+                            "Project Development", "Team", user, schedule, new ArrayList<>()),
+                    new Plan("Meeting", LocalDateTime.now(), LocalDateTime.now().plusHours(1), "Busan", "Team Meeting",
+                            "Staff", user, schedule, new ArrayList<>())
             );
-            Slice<Plan> planSlice =  new PageImpl<>(mockPlans, pageable, mockPlans.size());
+            Slice<Plan> planSlice = new PageImpl<>(mockPlans, pageable, mockPlans.size());
 
-            when(planRepository.findALLByUserIdAndScheduleId(userId,scheduleId)).thenReturn(mockPlans);
+            when(planRepository.findALLByUserIdAndScheduleId(userId, scheduleId)).thenReturn(mockPlans);
             when(planRepository.findALLByUserIdAndScheduleId(userId, scheduleId, pageable)).thenReturn(planSlice);
 
             PlanResponses responses = planService.findAll(userId, scheduleId, pageable);
@@ -151,5 +154,18 @@ class PlanServiceTest {
             assertThat(responses.getPlans()).extracting("title").containsExactlyInAnyOrder("Development", "Meeting");
         }
 
+        @DisplayName("일정 상세조회")
+        @Test
+        void find() {
+            Long userId = 1L;
+            Long planId = 1L;
+            Plan plan1 = mock(Plan.class);
+
+            when(planRepository.findByIdAndUserId(planId, userId)).thenReturn(Optional.of(plan1));
+
+            PlanResponse response = planService.find(userId, 1L);
+
+            assertThat(response).isNotNull();
+        }
     }
 }

--- a/src/test/java/com/example/tnote/plan/service/PlanServiceTest.java
+++ b/src/test/java/com/example/tnote/plan/service/PlanServiceTest.java
@@ -4,9 +4,12 @@ import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.example.tnote.boundedContext.plan.dto.PlanDeleteResponse;
 import com.example.tnote.boundedContext.plan.dto.PlanResponse;
 import com.example.tnote.boundedContext.plan.dto.PlanSaveRequest;
 import com.example.tnote.boundedContext.plan.entity.Plan;
@@ -21,6 +24,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Optional;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -51,20 +55,20 @@ class PlanServiceTest {
     @Nested
     @DisplayName("일정 생성/삭제")
     class saveAndDelete {
+        User user = mock(User.class);
+
+        LocalDate startDate = LocalDate.of(2024, 1, 10);
+        LocalDate endDate = LocalDate.of(2024, 1, 20);
+        Schedule schedule = new Schedule(1L, "1학기", null,
+                startDate, endDate, user);
+        LocalDateTime startDateTime = LocalDateTime.of(2024, 1, 11, 0, 0);
+        LocalDateTime endDateTime = LocalDateTime.of(2024, 1, 19, 0, 0);
 
         @DisplayName("일정 생성")
         @Test
         void save() {
-            User user = mock(User.class);
-
-            LocalDate startDate = LocalDate.of(2024, 1, 10);
-            LocalDate endDate = LocalDate.of(2024, 1, 20);
-            Schedule schedule = new Schedule(1L, "1학기", null,
-                    startDate, endDate, user);
-
-            LocalDateTime startDateTime = LocalDateTime.of(2024, 1, 11, 0, 0);
-            LocalDateTime endDateTime = LocalDateTime.of(2024, 1, 19, 0, 0);
-            PlanSaveRequest request = new PlanSaveRequest("Development", startDateTime, endDateTime, "Seoul", "Project Development", "Team");
+            PlanSaveRequest request = new PlanSaveRequest("Development", startDateTime, endDateTime, "Seoul",
+                    "Project Development", "Team");
 
             when(userRepository.findUserById(1L)).thenReturn(user);
             when(scheduleRepository.findScheduleById(1L)).thenReturn(schedule);
@@ -73,6 +77,24 @@ class PlanServiceTest {
             PlanResponse result = planService.save(1L, 1L, request, null);
 
             assertThat(result).isNotNull();
+        }
+
+        @DisplayName("일정 삭제")
+        @Test
+        void delete() {
+            Long planId = 1L;
+            Long userId = 1L;
+            Plan plan = new Plan("New Year Plan", startDateTime, endDateTime, "New York",
+                    "Celebration", "Everyone", user, schedule, new ArrayList<>());
+
+            when(planRepository.findByIdAndUserId(planId, userId)).thenReturn(Optional.of(plan));
+            doNothing().when(planRepository).delete(plan);
+
+            PlanDeleteResponse response = planService.delete(planId, userId);
+
+            assertThat(response).isNotNull();
+            assertThat(response.getId()).isEqualTo(plan.getId());
+            verify(planRepository).delete(plan);
         }
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

close #234 

## 📝작업 내용

- 일정 상세정보 조회 기능구현
- 일정 전체조회 기능 구현
- 일정 삭제 구현

## ✅테스트 결과

<img width="430" alt="image" src="https://github.com/user-attachments/assets/aafe1fbf-0071-4e15-a45e-e6894d710067">
